### PR TITLE
Keep submitted community proof URL working

### DIFF
--- a/legacy-url-manifest.json
+++ b/legacy-url-manifest.json
@@ -80,6 +80,16 @@
     "canonical": "https://kokomexcelsa.github.io/kokoweb/community/community.html"
   },
   {
+    "path": "/community.html",
+    "source": "community/community.html",
+    "category": "community-index-alias",
+    "migrationStatus": "generated-alias",
+    "sitemap": false,
+    "noindex": false,
+    "deploy": true,
+    "canonical": "https://kokomexcelsa.github.io/kokoweb/community/community.html"
+  },
+  {
     "path": "/company-template/companyT.html",
     "source": "company-template/companyT.html",
     "category": "legacy-template",

--- a/src/pages/community.astro
+++ b/src/pages/community.astro
@@ -1,0 +1,54 @@
+---
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+import CommunityPeriodPage from '../components/CommunityPeriodPage.astro';
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { withBase } from '../utils/url';
+
+type CommunityEntry = CollectionEntry<'communityPeriods'>;
+
+const communityPages = (await getCollection('communityPeriods')) as CommunityEntry[];
+const communityIndex = communityPages.find((entry) => entry.data.id === 'community');
+
+if (!communityIndex) {
+  throw new Error('Missing community index content record.');
+}
+
+const period = communityIndex.data;
+const site = Astro.site ?? new URL('https://kokomexcelsa.github.io');
+const pageUrl = new URL(withBase('/community.html'), site).toString();
+const canonicalUrl = new URL(withBase('/community/community.html'), site).toString();
+const structuredData = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    {
+      '@type': 'ListItem',
+      position: 1,
+      name: '首頁',
+      item: new URL(withBase('/index.html'), site).toString()
+    },
+    {
+      '@type': 'ListItem',
+      position: 2,
+      name: '社群活動',
+      item: pageUrl
+    }
+  ]
+};
+---
+
+<BaseLayout
+  title={`${period.title.zh} | 大魔術熊貓工程師`}
+  description="大魔術熊貓工程師社群活動規畫、管理與協辦紀錄。"
+  canonicalPath="/community/community.html"
+  structuredData={[structuredData, {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    url: pageUrl,
+    name: period.title.zh,
+    isPartOf: canonicalUrl
+  }]}
+>
+  <CommunityPeriodPage period={period} />
+</BaseLayout>


### PR DESCRIPTION
## Summary
- add `src/pages/community.astro` so the already-submitted MVP proof URL `https://kokomexcelsa.github.io/kokoweb/community.html` renders the community evidence page instead of 404
- track `/community.html` in the legacy URL manifest as a generated alias
- keep canonical URL pointed at `/community/community.html` to avoid duplicate SEO signals

## Validation
- `npm run validate`

## Notes
- This does not require changing the MVP application. It makes the URL already submitted to Microsoft work after the site deploys through Astro/GitHub Pages Actions.
- PR #4 was closed because it used the old branch and showed already-merged changes; this PR is the clean replacement from latest `master`.