### PR TITLE
Prevent community alias from being overwritten

### DIFF
--- a/scripts/copy-static-assets.mjs
+++ b/scripts/copy-static-assets.mjs
@@ -31,6 +31,7 @@ const files = [
 
 const generatedLegacyCategories = new Set([
   'community-index',
+  'community-index-alias',
   'community-period',
   'home',
   'speech-detail',


### PR DESCRIPTION
## Summary
- stop `copy-static-assets.mjs` from treating `/community.html` as a legacy passthrough file
- preserve the Astro-generated `/community.html` alias so it renders the same community evidence content as `/community/community.html`

## Validation
- `npm run validate`
- verified local `dist/community.html` contains `社群活動與管理紀錄` / `Community and User Group Ownership Evidence`, not the old `KoKo Mexcelsa社群活動規畫` page

## Why
PR #5 added the compatibility route, but the post-build legacy copy step overwrote `dist/community.html` with the old legacy HTML. This hotfix keeps the submitted MVP URL on the new evidence page after deploy.